### PR TITLE
Configure relative base path for Vite build output

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  base: './',
   root: resolve(__dirname, 'demo'),
   server: {
     port: 3013,


### PR DESCRIPTION
## Summary
Updated the Vite configuration to use a relative base path for the build output, enabling the application to be deployed in subdirectories without requiring an absolute root path.

## Changes
- Added `base: './'` configuration to `vite.config.ts` to set relative asset paths during build

## Details
This change ensures that all generated assets (JavaScript, CSS, images, etc.) use relative paths instead of absolute paths from the root. This is particularly useful for:
- Deploying the application to subdirectories or non-root paths
- Improving portability across different deployment environments
- Avoiding 404 errors when assets are served from a relative location

https://claude.ai/code/session_017Mqo93sYh5wsgwG8D6uJfd